### PR TITLE
Fix opening InAppBrowser

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -41,7 +41,7 @@ var app = {
 
         console.log('Received Event: ' + id);
 
-        var myref = cordova.InAppBrowser.open('iabpage.html');
+        var myref = cordova.InAppBrowser.open('iabpage.html', '_blank');
 
         myref.addEventListener('loadstart', function(e) {
             console.log('received loadstart for URL: ' + e.url);


### PR DESCRIPTION
Test app for https://github.com/apache/cordova-plugin-inappbrowser/pull/274.

The page opened by the InAppBrowser is in the whitelist (local page), so it is loaded in the Cordova WebView instead of InAppBrowser. This opens it in the InAppBrowser explicitely.